### PR TITLE
Set longer line length for md render

### DIFF
--- a/internal/pkg/markdown/markdown.go
+++ b/internal/pkg/markdown/markdown.go
@@ -11,6 +11,7 @@ func Render(path string) error {
 	r, _ := glamour.NewTermRenderer(
 		glamour.WithAutoStyle(),
 		glamour.WithEmoji(),
+		glamour.WithWordWrap(140), // TODO: make this configurable
 	)
 
 	data, err := ioutil.ReadFile(path)

--- a/internal/pkg/writer/writer.go
+++ b/internal/pkg/writer/writer.go
@@ -12,7 +12,9 @@ import (
 func Write(changeLog *changelog.ChangeLogProperties) error {
 	var tmplSrc = `# Changelog
 
-All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
+All notable changes to this project will be documented in this file. 
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
 {{range .Tags}}
 ## [{{.Tag}}](https://github.com/{{$.RepoOwner}}/{{$.RepoName}}/tree/{{.Tag}}) - ({{.Date.Format "2006-01-02"}})
 


### PR DESCRIPTION
This PR sets the line length for markdown rendering to 140 characters. It's a little bit more than the recommended of 80-100 characters, but it seems to fit the terminal well.