### PR TITLE
Fixes root commit reference

### DIFF
--- a/internal/pkg/writer/writer.go
+++ b/internal/pkg/writer/writer.go
@@ -12,7 +12,7 @@ import (
 func Write(changeLog *changelog.ChangeLogProperties) error {
 	var tmplSrc = `# Changelog
 
-All notable changes to this project will be documented in this file. 
+All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
 {{range .Tags}}


### PR DESCRIPTION
Prior to this commit, the last tag could potentially be compared with a commit that was not part of the current tree. This caused an invalid comparison.

This PR fixes that by using a git log equivalent to get the correct commit history.