### PR TITLE
Better config

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,32 @@ gh changelog new
 ```bash
 gh changelog show
 ```
+
+## Configuration
+
+Configuration for `gh changelog` can be found at `~/.config/gh-changelog/config.yaml`.
+However some sensible defaults are provided to help you get off to a flying start.
+
+```yaml
+# Labels added here will be ommitted from the changelog
+excluded_labels:
+  - maintenance
+# This is the filename of the generated changelog
+file_name: CHANGELOG.md
+# This is where labels are mapped to the sections in a changelog entry
+# The possible sections are restricted to: Added, Changed, Deprecated,
+# Removed, Fixed, Security.
+sections:
+  Changed:
+    - backwards-incompatible
+  Added:
+    - fixed
+    - enhancement
+  Fixed:
+    - bug
+    - bugfix
+    - documentation
+# When set to true, unlabelled entries will not be included in the changelog.
+# By default they will be grouped in a section named "Other".
+skip_entries_without_label: false
+```

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -18,7 +18,7 @@ var newCmd = &cobra.Command{
 	RunE: func(command *cobra.Command, args []string) error {
 		s := spinner.New(spinner.CharSets[11], 100*time.Millisecond)
 		_ = s.Color("green")
-		s.FinalMSG = fmt.Sprintf("✅ Open %s or run 'gh changelog show' to view your changelog.\n", viper.GetString("fileName"))
+		s.FinalMSG = fmt.Sprintf("✅ Open %s or run 'gh changelog show' to view your changelog.\n", viper.GetString("file_name"))
 
 		changeLog, err := changelog.MakeFullChangelog(s)
 		if err != nil {

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -12,7 +12,7 @@ var showCmd = &cobra.Command{
 	Long:  "Renders the changelog in the terminal",
 	RunE: func(command *cobra.Command, args []string) error {
 
-		changelog := viper.GetString("fileName")
+		changelog := viper.GetString("file_name")
 		return markdown.Render(changelog)
 	},
 }

--- a/internal/pkg/changelog/changelog.go
+++ b/internal/pkg/changelog/changelog.go
@@ -62,7 +62,7 @@ func MakeFullChangelog(spinner *spinner.Spinner) (*ChangeLogProperties, error) {
 			nextTag.Name,
 			currentTag.Date,
 			pullRequests,
-			viper.GetStringSlice("excludedLabels"),
+			viper.GetStringSlice("excluded_labels"),
 			client.RepoContext,
 		)
 		if err != nil {
@@ -93,7 +93,7 @@ func getTagProperties(currentTag string, nextTag string, date time.Time, pullReq
 			section := getSection(pr.Labels)
 			err := tagProperties.Append(section, entry)
 			if err != nil {
-				return nil, fmt.Errorf("❌ could not append entry: %v", err)
+				return nil, err
 			}
 		}
 	}
@@ -121,11 +121,16 @@ func getSection(labels []*github.Label) string {
 		}
 	}
 
-	section := "Other"
+	section := ""
 	for _, label := range labels {
 		if _, ok := lookup[label.GetName()]; ok {
 			section = lookup[label.GetName()]
 		}
+	}
+
+	skipUnlabelledEntries := viper.GetBool("skip_entries_without_label")
+	if !skipUnlabelledEntries {
+		section = "Other"
 	}
 
 	return section

--- a/internal/pkg/changelog/properties.go
+++ b/internal/pkg/changelog/properties.go
@@ -65,7 +65,7 @@ func (tp *TagProperties) Append(section string, entry string) error {
 	case "other":
 		tp.Other = append(tp.Other, entry)
 	default:
-		return fmt.Errorf("unknown entry type: %s", section)
+		return fmt.Errorf("unknown entry type '%s'", section)
 	}
 
 	return nil

--- a/internal/pkg/configuration/configuration.go
+++ b/internal/pkg/configuration/configuration.go
@@ -11,11 +11,8 @@ import (
 func InitConfig() error {
 	home, _ := os.UserHomeDir()
 
-	cfgFile := "config.yml"
-	viper.SetConfigName(cfgFile)
+	viper.SetConfigName("config")
 	viper.SetConfigType("yaml")
-
-	viper.AddConfigPath(home)
 
 	cfgPath := filepath.Join(home, ".config", "gh-changelog")
 	viper.AddConfigPath(cfgPath)
@@ -26,28 +23,23 @@ func InitConfig() error {
 		}
 	}
 
-	cfgFilePath := filepath.Join(cfgPath, cfgFile)
-
-	if _, err := os.Stat(cfgFilePath); os.IsNotExist(err) {
-		_, err := os.Create(filepath.Clean(cfgFilePath))
-		if err != nil {
-			return fmt.Errorf("failed to initialise %s: %s", cfgFilePath, err)
-		}
+	SetDefaults()
+	err := viper.SafeWriteConfig()
+	if err != nil {
+		return fmt.Errorf("failed to write config: %s", err)
 	}
 
-	err := viper.ReadInConfig()
+	err = viper.ReadInConfig()
 	if err != nil {
 		return fmt.Errorf("failed to read config: %s", err)
 	}
 
-	setDefaults()
-
 	return nil
 }
 
-func setDefaults() {
-	viper.SetDefault("fileName", "CHANGELOG.md")
-	viper.SetDefault("excludedLabels", []string{"maintenance"})
+func SetDefaults() {
+	viper.SetDefault("file_name", "CHANGELOG.md")
+	viper.SetDefault("excluded_labels", []string{"maintenance"})
 
 	sections := make(map[string][]string)
 	sections["Changed"] = []string{"backwards-incompatible"}
@@ -55,4 +47,6 @@ func setDefaults() {
 	sections["Fixed"] = []string{"bug", "bugfix", "documentation"}
 
 	viper.SetDefault("sections", sections)
+
+	viper.SetDefault("skip_entries_without_label", false)
 }

--- a/internal/pkg/writer/writer.go
+++ b/internal/pkg/writer/writer.go
@@ -80,7 +80,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 	tmpl := template.Must(template.New("changelog").Parse(tmplSrc))
 
-	fileName := viper.GetString("fileName")
+	fileName := viper.GetString("file_name")
 	f, err := os.Create(fileName)
 	if err != nil {
 		return err


### PR DESCRIPTION
Prior to this PR, it was not clear how to configure this tool. There were defaults set within the application but you needed to look at the source code to find out what they were.

This PR improves the config system by writing out a config file that contains the defaults supported by the application.

Closes #26 