### PR TITLE
Implementation of next-version and unreleased

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,8 @@ jobs:
         with:
           version: latest
 
-      # - name: test
-      #   run: go test -v ./...
+      - name: test
+        run: go test -v ./...
 
   release:
     name: release  

--- a/Makefile
+++ b/Makefile
@@ -8,5 +8,6 @@ lint:
 build:
 	@WORKINGDIR=$(pwd) goreleaser build --snapshot --rm-dist --single-target
 
+.PHONY: mocks
 mocks:
-	@mockery --all --keeptree
+	@mockery --all

--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ gh extension upgrade chelnak/gh-changelog
 gh changelog new
 ```
 
+### Create a new changelog for an untagged version
+
+```bash
+gh changelog new --next-version v1.2.0
+```
+
 ### View your changelog in the terminal
 
 ```bash
@@ -72,4 +78,8 @@ sections:
 # When set to true, unlabelled entries will not be included in the changelog.
 # By default they will be grouped in a section named "Other".
 skip_entries_without_label: false
+# Adds an unreleased section to the changelog. This will contain any qualifying entries
+# that have been added since the last tag.
+# Note: The unreleased section is not created when the --next-version flag is used.
+show_unreleased: true
 ```

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -9,6 +9,8 @@ import (
 	"github.com/spf13/viper"
 )
 
+var nextVersion string
+
 // newCmd is the entry point for creating a new changelog
 var newCmd = &cobra.Command{
 	Use:   "new",
@@ -17,6 +19,7 @@ var newCmd = &cobra.Command{
 	RunE: func(command *cobra.Command, args []string) error {
 		builder := changelog.NewChangelogBuilder()
 		builder = builder.WithSpinner(true)
+		builder = builder.WithNextVersion(nextVersion)
 
 		changelog, err := builder.Build()
 		if err != nil {
@@ -31,4 +34,8 @@ var newCmd = &cobra.Command{
 
 		return writer.Write(f, changelog)
 	},
+}
+
+func init() {
+	newCmd.Flags().StringVar(&nextVersion, "next-version", "", "The next version to be released. The value passed does not have to be an existing tag.")
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/chelnak/gh-changelog
 go 1.18
 
 require (
+	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/briandowns/spinner v1.18.1
 	github.com/charmbracelet/bubbles v0.10.3
 	github.com/charmbracelet/bubbletea v0.20.0

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
+github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
+github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/alecthomas/chroma v0.10.0 h1:7XDcGkCQopCNKjZHfYrNLraA+M7e0fMiJ/Mfikbfjek=
 github.com/alecthomas/chroma v0.10.0/go.mod h1:jtJATyUxlIORhUOFNA9NZDWGAQ8wpxQQqNSB4rjA/1s=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=

--- a/internal/pkg/configuration/configuration.go
+++ b/internal/pkg/configuration/configuration.go
@@ -23,8 +23,9 @@ func InitConfig() error {
 		}
 	}
 
+	SetDefaults()
+
 	if err := viper.ReadInConfig(); err != nil {
-		SetDefaults()
 		err := viper.SafeWriteConfig()
 		if err != nil {
 			return fmt.Errorf("failed to write config: %s", err)
@@ -46,4 +47,6 @@ func SetDefaults() {
 	viper.SetDefault("sections", sections)
 
 	viper.SetDefault("skip_entries_without_label", false)
+
+	viper.SetDefault("show_unreleased", true)
 }

--- a/internal/pkg/gitclient/client.go
+++ b/internal/pkg/gitclient/client.go
@@ -8,13 +8,8 @@ import (
 
 type GitClient interface {
 	GetFirstCommit() (string, error)
+	GetLastCommit() (string, error)
 	GetDateOfHash(hash string) (time.Time, error)
-}
-
-type Tag struct {
-	Name string
-	Sha  string
-	Date time.Time
 }
 
 type execOptions struct {
@@ -42,6 +37,12 @@ func (g git) GetFirstCommit() (string, error) {
 	})
 }
 
+func (g git) GetLastCommit() (string, error) {
+	return g.exec(execOptions{
+		args: []string{"log", "-1", "--pretty=format:%H"},
+	})
+}
+
 func (g git) GetDateOfHash(hash string) (time.Time, error) {
 	date, err := g.exec(execOptions{
 		args: []string{"log", "-1", "--format=%cI", hash, "--date=local"},
@@ -50,6 +51,7 @@ func (g git) GetDateOfHash(hash string) (time.Time, error) {
 	if err != nil {
 		return time.Time{}, err
 	}
+
 	return time.ParseInLocation(time.RFC3339, date, time.Local)
 }
 

--- a/internal/pkg/githubclient/client.go
+++ b/internal/pkg/githubclient/client.go
@@ -90,8 +90,6 @@ func (client *githubClient) GetTags() ([]Tag, error) {
 			return nil, fmt.Errorf("error getting tags: %w", err)
 		}
 
-		fmt.Println(TagQuery)
-
 		for _, node := range TagQuery.Repository.Refs.Nodes {
 			switch node.Target.TypeName {
 			case "Tag":

--- a/internal/pkg/githubclient/client_test.go
+++ b/internal/pkg/githubclient/client_test.go
@@ -1,7 +1,6 @@
 package githubclient_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/chelnak/gh-changelog/internal/pkg/githubclient"
@@ -55,8 +54,6 @@ func Test_GetTagsReturnsASliceOfTags(t *testing.T) {
 	assert.NoError(t, err)
 
 	tags, err := client.GetTags()
-
-	fmt.Println(tags)
 
 	assert.NoError(t, err)
 

--- a/internal/pkg/utils/utils.go
+++ b/internal/pkg/utils/utils.go
@@ -1,5 +1,9 @@
 package utils
 
+import (
+	"github.com/Masterminds/semver/v3"
+)
+
 func SliceContainsString(s []string, str string) bool {
 	for _, v := range s {
 		if v == str {
@@ -8,4 +12,9 @@ func SliceContainsString(s []string, str string) bool {
 	}
 
 	return false
+}
+
+func IsValidSemanticVersion(version string) bool {
+	_, err := semver.NewVersion(version)
+	return err == nil
 }

--- a/internal/pkg/utils/utils_test.go
+++ b/internal/pkg/utils/utils_test.go
@@ -35,3 +35,30 @@ func TestSliceContainsString(t *testing.T) {
 		})
 	}
 }
+
+func TestIsValidSemanticVersion(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{
+			name:  "valid semantic version",
+			value: "1.0.0",
+			want:  true,
+		},
+		{
+			name:  "invalid semantic version",
+			value: "asdasdasd1",
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := utils.IsValidSemanticVersion(tt.value); got != tt.want {
+				t.Errorf("IsValidSemanticVersion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/pkg/writer/writer.go
+++ b/internal/pkg/writer/writer.go
@@ -14,7 +14,17 @@ func Write(writer io.Writer, changelog changelog.Changelog) error {
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
+
+{{- $unreleased := .GetUnreleased }}
+{{- if $unreleased }}
+
+## Unreleased
+{{range $unreleased }}
+- {{.}}
+{{- end}}
+{{- end -}}
 {{range .GetEntries}}
+
 ## [{{.CurrentTag}}](https://github.com/{{$.GetRepoOwner}}/{{$.GetRepoName}}/tree/{{.CurrentTag}}) - ({{.Date.Format "2006-01-02"}})
 
 [Full Changelog](https://github.com/{{$.GetRepoOwner}}/{{$.GetRepoName}}/compare/{{.PreviousTag}}...{{.CurrentTag}})

--- a/internal/pkg/writer/writer_test.go
+++ b/internal/pkg/writer/writer_test.go
@@ -32,11 +32,17 @@ func Test_ItWritesOutAChangelogInTheCorrectFormat(t *testing.T) {
 		},
 	})
 
+	mockChangelog.On("GetUnreleased").Return([]string{"Unreleased 1", "Unreleased 2"})
+
 	var buf bytes.Buffer
 	err := writer.Write(&buf, mockChangelog)
 
 	assert.NoError(t, err)
 	mockChangelog.AssertExpectations(t)
+
+	assert.Regexp(t, "## Unreleased", buf.String())
+	assert.Regexp(t, "- Unreleased 1", buf.String())
+	assert.Regexp(t, "- Unreleased 2", buf.String())
 
 	assert.Regexp(t, regexp.MustCompile(`## \[v1.0.0\]\(https:\/\/github.com\/TestOwner\/TestRepo\/tree\/v1.0.0\)`), buf.String())
 	assert.Regexp(t, "### Added", buf.String())

--- a/mocks/Changelog.go
+++ b/mocks/Changelog.go
@@ -58,6 +58,22 @@ func (_m *Changelog) GetRepoOwner() string {
 	return r0
 }
 
+// GetUnreleased provides a mock function with given fields:
+func (_m *Changelog) GetUnreleased() []string {
+	ret := _m.Called()
+
+	var r0 []string
+	if rf, ok := ret.Get(0).(func() []string); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+
+	return r0
+}
+
 // NewChangelog creates a new instance of Changelog. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewChangelog(t testing.TB) *Changelog {
 	mock := &Changelog{}

--- a/mocks/ChangelogBuilder.go
+++ b/mocks/ChangelogBuilder.go
@@ -73,6 +73,22 @@ func (_m *ChangelogBuilder) WithGithubClient(client githubclient.GitHubClient) c
 	return r0
 }
 
+// WithNextVersion provides a mock function with given fields: nextVersion
+func (_m *ChangelogBuilder) WithNextVersion(nextVersion string) changelog.ChangelogBuilder {
+	ret := _m.Called(nextVersion)
+
+	var r0 changelog.ChangelogBuilder
+	if rf, ok := ret.Get(0).(func(string) changelog.ChangelogBuilder); ok {
+		r0 = rf(nextVersion)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(changelog.ChangelogBuilder)
+		}
+	}
+
+	return r0
+}
+
 // WithSpinner provides a mock function with given fields: enabled
 func (_m *ChangelogBuilder) WithSpinner(enabled bool) changelog.ChangelogBuilder {
 	ret := _m.Called(enabled)

--- a/mocks/GitClient.go
+++ b/mocks/GitClient.go
@@ -57,6 +57,27 @@ func (_m *GitClient) GetFirstCommit() (string, error) {
 	return r0, r1
 }
 
+// GetLastCommit provides a mock function with given fields:
+func (_m *GitClient) GetLastCommit() (string, error) {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // NewGitClient creates a new instance of GitClient. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewGitClient(t testing.TB) *GitClient {
 	mock := &GitClient{}


### PR DESCRIPTION
This PR adds support for an unreleased section and also adds an optional next-version flag.

The unreleased section will display any qualifying entries that have been added since the last tag.

The next-version flag allows the user to specify an arbitrary version number to use for the next release. 

If used, any qualifying entries that have been added since the last tag will be grouped here and the unreleased section will not be shown.
