### PR TITLE
Fix error messages

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,7 +45,7 @@ func init() {
 func Execute() int {
 	if err := rootCmd.Execute(); err != nil {
 		if err != errSilent {
-			fmt.Fprintln(os.Stderr, err)
+			fmt.Fprintln(os.Stderr, fmt.Errorf("❌ %s", err))
 		}
 		return 1
 	}

--- a/internal/pkg/markdown/markdown.go
+++ b/internal/pkg/markdown/markdown.go
@@ -16,7 +16,7 @@ func Render(path string) error {
 
 	data, err := ioutil.ReadFile(path)
 	if err != nil {
-		return errors.New("❌ changelog not found. Check your configuration or run gh changelog new")
+		return errors.New("changelog not found. Check your configuration or run gh changelog new")
 	}
 
 	content, err := r.Render(string(data))


### PR DESCRIPTION
Prior to this commit, when the application exited with an error, the resulting message did not contain a red cross.

This commit adds the red cross to the error message. However it is only done in the root execute function.