### PR TITLE
Rework configuration

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -4,9 +4,9 @@ import (
 	"os"
 
 	"github.com/chelnak/gh-changelog/internal/pkg/changelog"
+	"github.com/chelnak/gh-changelog/internal/pkg/configuration"
 	"github.com/chelnak/gh-changelog/internal/pkg/writer"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var nextVersion string
@@ -26,7 +26,7 @@ var newCmd = &cobra.Command{
 			return err
 		}
 
-		fileName := viper.GetString("file_name")
+		fileName := configuration.Config.FileName
 		f, err := os.Create(fileName)
 		if err != nil {
 			return err

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,7 +8,6 @@ import (
 	"github.com/chelnak/gh-changelog/internal/pkg/configuration"
 	"github.com/chelnak/gh-changelog/internal/pkg/utils"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var version = "dev"
@@ -24,7 +23,7 @@ var rootCmd = &cobra.Command{
 	SilenceErrors: true,
 	Run:           nil,
 	PersistentPostRun: func(cmd *cobra.Command, args []string) {
-		if viper.GetBool("check_for_updates") {
+		if configuration.Config.CheckForUpdates {
 			utils.CheckForUpdate(version)
 		}
 	},

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -1,9 +1,9 @@
 package cmd
 
 import (
+	"github.com/chelnak/gh-changelog/internal/pkg/configuration"
 	"github.com/chelnak/gh-changelog/internal/pkg/markdown"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 // showCmd is the entry point for rendering a changelog in the terminal
@@ -12,7 +12,7 @@ var showCmd = &cobra.Command{
 	Short: "Renders the current changelog in the terminal",
 	Long:  "Renders the current changelog in the terminal",
 	RunE: func(command *cobra.Command, args []string) error {
-		changelog := viper.GetString("file_name")
+		changelog := configuration.Config.FileName
 		return markdown.Render(changelog)
 	},
 }

--- a/internal/pkg/configuration/configuration.go
+++ b/internal/pkg/configuration/configuration.go
@@ -8,6 +8,17 @@ import (
 	"github.com/spf13/viper"
 )
 
+var Config configuration
+
+type configuration struct {
+	FileName                string              `mapstructure:"file_name"`
+	ExcludedLabels          []string            `mapstructure:"excluded_labels"`
+	Sections                map[string][]string `mapstructure:"sections"`
+	SkipEntriesWithoutLabel bool                `mapstructure:"skip_entries_without_label"`
+	ShowUnreleased          bool                `mapstructure:"show_unreleased"`
+	CheckForUpdates         bool                `mapstructure:"check_for_updates"`
+}
+
 func InitConfig() error {
 	home, _ := os.UserHomeDir()
 
@@ -23,7 +34,7 @@ func InitConfig() error {
 		}
 	}
 
-	SetDefaults()
+	setDefaults()
 
 	if err := viper.ReadInConfig(); err != nil {
 		err := viper.SafeWriteConfig()
@@ -32,10 +43,15 @@ func InitConfig() error {
 		}
 	}
 
+	err := viper.Unmarshal(&Config)
+	if err != nil {
+		return fmt.Errorf("failed to parse config: %s", err)
+	}
+
 	return nil
 }
 
-func SetDefaults() {
+func setDefaults() {
 	viper.SetDefault("file_name", "CHANGELOG.md")
 	viper.SetDefault("excluded_labels", []string{"maintenance"})
 


### PR DESCRIPTION
This PR reworks how configuration is consumed throughout the app.

Previously, we would call viper directly in respective packages to retrieve configuration values. Now, we unmarshal; in to a struct and consume it where required.