### PR TITLE
Tests for changelog package

### DIFF
--- a/internal/pkg/changelog/builder_test.go
+++ b/internal/pkg/changelog/builder_test.go
@@ -1,0 +1,101 @@
+package changelog_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/chelnak/gh-changelog/internal/pkg/changelog"
+	"github.com/chelnak/gh-changelog/internal/pkg/configuration"
+	"github.com/chelnak/gh-changelog/internal/pkg/githubclient"
+	"github.com/chelnak/gh-changelog/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func safeParseTime() time.Time {
+	time, _ := time.Parse(time.RFC3339, time.Time{}.String())
+	return time
+}
+
+func setupMockGitClient() *mocks.GitClient {
+	mockGitClient := &mocks.GitClient{}
+	mockGitClient.On("GetFirstCommit").Return("42d4c93b23eaf307c5f9712f4c62014fe38332bd", nil)
+	mockGitClient.On("GetLastCommit").Return("0d724ba5b4235aa88d45a20f4ecd8db4b4695cf1", nil)
+	mockGitClient.On("GetDateOfHash", "42d4c93b23eaf307c5f9712f4c62014fe38332bd").Return(safeParseTime(), nil).Once()
+	return mockGitClient
+}
+
+func setupMockGitHubClient() *mocks.GitHubClient {
+	mockGitHubClient := &mocks.GitHubClient{}
+	mockGitHubClient.On("GetTags").Return([]githubclient.Tag{
+		{
+			Name: "v1.0.0",
+			Sha:  "42d4c93b23eaf307c5f9712f4c62014fe38332bd",
+			Date: safeParseTime(),
+		},
+		{
+			Name: "v2.0.0",
+			Sha:  "0d724ba5b4235aa88d45a20f4ecd8db4b4695cf1",
+			Date: safeParseTime(),
+		},
+	}, nil)
+
+	// bad ??
+	changelog.Now = func() time.Time {
+		return safeParseTime()
+	}
+
+	mockGitHubClient.On("GetPullRequestsBetweenDates", safeParseTime(), changelog.Now()).Return([]githubclient.PullRequest{}, nil).Once()
+	mockGitHubClient.On("GetPullRequestsBetweenDates", time.Time{}, time.Time{}).Return([]githubclient.PullRequest{
+		{
+			Number: 1,
+			Title:  "this is a test pr",
+			User:   "test-user",
+			Labels: []githubclient.Label{
+				{
+					Name: "enhancement",
+				},
+			},
+		},
+		{
+			Number: 2,
+			Title:  "this is a test pr 2",
+			User:   "test-user",
+			Labels: []githubclient.Label{
+				{
+					Name: "enhancement",
+				},
+			},
+		},
+	}, nil)
+
+	mockGitHubClient.On("GetRepoName").Return(repoName)
+	mockGitHubClient.On("GetRepoOwner").Return(repoOwner)
+
+	return mockGitHubClient
+}
+
+var testBuilder = changelog.NewChangelogBuilder()
+
+func TestChangelogBuilder(t *testing.T) {
+	_ = configuration.InitConfig()
+
+	mockGitClient := setupMockGitClient()
+	mockGitHubClient := setupMockGitHubClient()
+
+	testBuilder.WithSpinner(true)
+	testBuilder.WithGitClient(mockGitClient)
+	testBuilder.WithGitHubClient(mockGitHubClient)
+
+	changelog, err := testBuilder.Build()
+	assert.NoError(t, err)
+
+	assert.Equal(t, changelog.GetRepoName(), "repo-name")
+	assert.Equal(t, changelog.GetRepoOwner(), "repo-owner")
+
+	assert.Len(t, changelog.GetUnreleased(), 0)
+	assert.Len(t, changelog.GetEntries(), 2)
+
+	fmt.Println(changelog.GetEntries())
+	assert.Equal(t, changelog.GetEntries()[0].Added[0], "this is a test pr [#1](https://github.com/repo-owner/repo-name/pull/1) ([test-user](https://github.com/test-user))\n")
+}

--- a/internal/pkg/changelog/changelog.go
+++ b/internal/pkg/changelog/changelog.go
@@ -19,7 +19,7 @@ type Entry struct {
 	Other       []string
 }
 
-func (e *Entry) append(section string, entry string) error {
+func (e *Entry) Append(section string, entry string) error {
 	switch strings.ToLower(section) {
 	case "added":
 		e.Added = append(e.Added, entry)
@@ -45,8 +45,10 @@ func (e *Entry) append(section string, entry string) error {
 type Changelog interface {
 	GetRepoName() string
 	GetRepoOwner() string
-	GetUnreleased() []string
 	GetEntries() []Entry
+	AddEntry(Entry)
+	GetUnreleased() []string
+	AddUnreleased([]string)
 }
 
 type changelog struct {
@@ -54,6 +56,15 @@ type changelog struct {
 	repoOwner  string
 	unreleased []string
 	entries    []Entry
+}
+
+func NewChangelog(repoName string, repoOwner string) Changelog {
+	return &changelog{
+		repoName:   repoName,
+		repoOwner:  repoOwner,
+		unreleased: []string{},
+		entries:    []Entry{},
+	}
 }
 
 func (c *changelog) GetRepoName() string {
@@ -68,6 +79,14 @@ func (c *changelog) GetEntries() []Entry {
 	return c.entries
 }
 
+func (c *changelog) AddEntry(entry Entry) {
+	c.entries = append(c.entries, entry)
+}
+
 func (c *changelog) GetUnreleased() []string {
 	return c.unreleased
+}
+
+func (c *changelog) AddUnreleased(entry []string) {
+	c.unreleased = append(c.unreleased, entry...)
 }

--- a/internal/pkg/changelog/changelog_test.go
+++ b/internal/pkg/changelog/changelog_test.go
@@ -1,1 +1,51 @@
 package changelog_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/chelnak/gh-changelog/internal/pkg/changelog"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	repoName  = "repo-name"
+	repoOwner = "repo-owner"
+)
+
+var testChangelog = changelog.NewChangelog(repoName, repoOwner)
+
+func TetstNewChangelog(t *testing.T) {
+	assert.Equal(t, repoName, testChangelog.GetRepoName())
+	assert.Equal(t, repoOwner, testChangelog.GetRepoOwner())
+	assert.Equal(t, 0, len(testChangelog.GetEntries()))
+	assert.Equal(t, 0, len(testChangelog.GetUnreleased()))
+}
+
+func TestAddEntry(t *testing.T) {
+	entry := changelog.Entry{
+		CurrentTag:  "v2.0.0",
+		PreviousTag: "v1.0.0",
+		Date:        time.Time{},
+	}
+
+	err := entry.Append("added", "test")
+	assert.Nil(t, err)
+
+	testChangelog.AddEntry(entry)
+
+	entries := testChangelog.GetEntries()
+
+	assert.Equal(t, 1, len(entries))
+	assert.Equal(t, 1, len(entries[0].Added))
+	assert.Equal(t, "test", entries[0].Added[0])
+}
+
+func TestAddingAndRetrievingUnreleasedReturnsTheCorrectResponse(t *testing.T) {
+	testChangelog.AddUnreleased([]string{"test"})
+
+	unreleased := testChangelog.GetUnreleased()
+
+	assert.Equal(t, 1, len(unreleased))
+	assert.Equal(t, "test", unreleased[0])
+}

--- a/internal/pkg/githubclient/client_test.go
+++ b/internal/pkg/githubclient/client_test.go
@@ -29,7 +29,7 @@ func Test_ItReturnsTheCorrectRepoOwner(t *testing.T) {
 	assert.Equal(t, "TestOwner", repoName)
 }
 
-func newJsonResponder(status int, body string) httpmock.Responder {
+func NewJSONResponder(status int, body string) httpmock.Responder {
 	resp := httpmock.NewStringResponse(status, body)
 	resp.Header.Set("Content-Type", "application/json")
 	return httpmock.ResponderFromResponse(resp)
@@ -41,7 +41,7 @@ func Test_GetTagsReturnsASliceOfTags(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 	httpmock.RegisterResponder("POST", "https://api.github.com/graphql",
-		newJsonResponder(500, httpmock.File("data/get_tags_response.json").String()),
+		NewJSONResponder(500, httpmock.File("data/get_tags_response.json").String()),
 	)
 
 	t.Setenv("GITHUB_TOKEN", "xxxxxxxx")

--- a/internal/pkg/writer/writer_test.go
+++ b/internal/pkg/writer/writer_test.go
@@ -8,43 +8,43 @@ import (
 
 	"github.com/chelnak/gh-changelog/internal/pkg/changelog"
 	"github.com/chelnak/gh-changelog/internal/pkg/writer"
-	"github.com/chelnak/gh-changelog/mocks"
 	"github.com/stretchr/testify/assert"
 )
 
+const (
+	repoName  = "repo-name"
+	repoOwner = "repo-owner"
+)
+
 func Test_ItWritesOutAChangelogInTheCorrectFormat(t *testing.T) {
-	mockChangelog := &mocks.Changelog{}
+	mockChangelog := changelog.NewChangelog(repoName, repoOwner)
 
-	mockChangelog.On("GetRepoName").Return("TestRepo")
-	mockChangelog.On("GetRepoOwner").Return("TestOwner")
-	mockChangelog.On("GetEntries").Return([]changelog.Entry{
-		{
-			CurrentTag:  "v1.0.0",
-			PreviousTag: "v0.0.0",
-			Date:        time.Now(),
-			Added:       []string{"Added 1", "Added 2"},
-			Changed:     []string{"Changed 1", "Changed 2"},
-			Deprecated:  []string{"Deprecated 1", "Deprecated 2"},
-			Removed:     []string{"Removed 1", "Removed 2"},
-			Fixed:       []string{"Fixed 1", "Fixed 2"},
-			Security:    []string{"Security 1", "Security 2"},
-			Other:       []string{"Other 1", "Other 2"},
-		},
-	})
+	entry := changelog.Entry{
+		CurrentTag:  "v1.0.0",
+		PreviousTag: "v0.0.0",
+		Date:        time.Now(),
+		Added:       []string{"Added 1", "Added 2"},
+		Changed:     []string{"Changed 1", "Changed 2"},
+		Deprecated:  []string{"Deprecated 1", "Deprecated 2"},
+		Removed:     []string{"Removed 1", "Removed 2"},
+		Fixed:       []string{"Fixed 1", "Fixed 2"},
+		Security:    []string{"Security 1", "Security 2"},
+		Other:       []string{"Other 1", "Other 2"},
+	}
 
-	mockChangelog.On("GetUnreleased").Return([]string{"Unreleased 1", "Unreleased 2"})
+	mockChangelog.AddEntry(entry)
+	mockChangelog.AddUnreleased([]string{"Unreleased 1", "Unreleased 2"})
 
 	var buf bytes.Buffer
 	err := writer.Write(&buf, mockChangelog)
 
 	assert.NoError(t, err)
-	mockChangelog.AssertExpectations(t)
 
 	assert.Regexp(t, "## Unreleased", buf.String())
 	assert.Regexp(t, "- Unreleased 1", buf.String())
 	assert.Regexp(t, "- Unreleased 2", buf.String())
 
-	assert.Regexp(t, regexp.MustCompile(`## \[v1.0.0\]\(https:\/\/github.com\/TestOwner\/TestRepo\/tree\/v1.0.0\)`), buf.String())
+	assert.Regexp(t, regexp.MustCompile(`## \[v1.0.0\]\(https:\/\/github.com\/repo-owner\/repo-name\/tree\/v1.0.0\)`), buf.String())
 	assert.Regexp(t, "### Added", buf.String())
 	assert.Regexp(t, "- Added 1", buf.String())
 	assert.Regexp(t, "- Added 2", buf.String())


### PR DESCRIPTION
This commit adds gets for the `changelog` package.

It also includes some refactoring of `builde`r & `changelog` to use some modified methods that were changed while writing tests.

Writer tests have also been updated to use the new `NewChangelog` method.