### PR TITLE
Enable configuration from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,11 @@ show_unreleased: true
 # If set to false, the tool will not check remotely for updates
 check_for_updates: true
 ```
+
+You can also override any setting using environment variables. When configured from the environment
+properties are prefixed with `CHANGELOG`. For example, overriding `check_for_updates` might look
+something like this:
+
+```bash
+export CHANGELOG_CHECK_FOR_UPDATES=false
+```

--- a/internal/pkg/configuration/configuration.go
+++ b/internal/pkg/configuration/configuration.go
@@ -43,6 +43,9 @@ func InitConfig() error {
 		}
 	}
 
+	viper.AutomaticEnv()
+	viper.SetEnvPrefix("changelog")
+
 	err := viper.Unmarshal(&Config)
 	if err != nil {
 		return fmt.Errorf("failed to parse config: %s", err)


### PR DESCRIPTION
Prior to this PR users could only configure the application via the config file.

This PR enables vipers automatic environment feature to allow optional configuration from environment variables.

Closes #55 