### PR TITLE
Add a command to view current config

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,18 @@ gh changelog new --next-version v1.2.0
 gh changelog show
 ```
 
+### View the current configuration in the terminal
+
+```bash
+gh changelog config
+```
+
+Or to print out JSON instead of YAML:
+
+```bash
+gh changelog config -o json
+```
+
 ## Configuration
 
 Configuration for `gh changelog` can be found at `~/.config/gh-changelog/config.yaml`.

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,0 +1,48 @@
+//Package cmd holds all top-level cobra commands. Each file should contain
+//only one command and that command should have only one purpose.
+package cmd
+
+import (
+	"bufio"
+	"errors"
+	"os"
+
+	"github.com/chelnak/gh-changelog/internal/pkg/configuration"
+	"github.com/spf13/cobra"
+)
+
+var output string
+
+// configCmd is the entry point for printing the applications configuration in the terminal
+var configCmd = &cobra.Command{
+	Use:   "config",
+	Short: "Prints the current configuration to the terminal in either json or yaml format. Defaults to yaml.",
+	Long:  "Prints the current configuration to the terminal in either json or yaml format. Defaults to yaml.",
+	RunE: func(command *cobra.Command, args []string) error {
+
+		writer := bufio.NewWriter(os.Stdout)
+
+		var err error
+		defer func() {
+			err = writer.Flush()
+		}()
+
+		if err != nil {
+			return err
+		}
+
+		switch output {
+		case "json":
+			return configuration.Config.PrintJSON(writer)
+		case "yaml":
+			return configuration.Config.PrintYAML(writer)
+		default:
+			return errors.New("invalid output format. Valid values are 'json' and 'yaml'")
+		}
+
+	},
+}
+
+func init() {
+	configCmd.Flags().StringVarP(&output, "output", "o", "yaml", "The output format. Valid values are 'json' and 'yaml'. Defaults to 'yaml'.")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -46,6 +46,7 @@ func init() {
 
 	rootCmd.AddCommand(newCmd)
 	rootCmd.AddCommand(showCmd)
+	rootCmd.AddCommand(configCmd)
 }
 
 // Execute is called from main and is responsible for processing

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/spf13/viper v1.11.0
 	github.com/stretchr/testify v1.7.1
 	gopkg.in/h2non/gock.v1 v1.1.2
+	gopkg.in/yaml.v2 v2.4.0
 )
 
 require (
@@ -59,11 +60,10 @@ require (
 	github.com/yuin/goldmark v1.4.4 // indirect
 	github.com/yuin/goldmark-emoji v1.0.1 // indirect
 	golang.org/x/net v0.0.0-20220421235706-1d1ef9303861 // indirect
-	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad // indirect
+	golang.org/x/sys v0.0.0-20220513210249-45d2b4557a2a // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/ini.v1 v1.66.4 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -406,8 +406,8 @@ golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220412211240-33da011f77ad h1:ntjMns5wyP/fN65tdBD4g8J5w8n015+iIIs9rtjXkY0=
-golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220513210249-45d2b4557a2a h1:N2T1jUrTQE9Re6TFF5PhvEHXHCguynGhKjWVsIUt5cY=
+golang.org/x/sys v0.0.0-20220513210249-45d2b4557a2a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210422114643-f5beecf764ed/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=

--- a/internal/pkg/configuration/configuration.go
+++ b/internal/pkg/configuration/configuration.go
@@ -7,22 +7,49 @@
 package configuration
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
 	"github.com/spf13/viper"
+	"gopkg.in/yaml.v2"
 )
 
 var Config configuration
 
 type configuration struct {
-	FileName                string              `mapstructure:"file_name"`
-	ExcludedLabels          []string            `mapstructure:"excluded_labels"`
-	Sections                map[string][]string `mapstructure:"sections"`
-	SkipEntriesWithoutLabel bool                `mapstructure:"skip_entries_without_label"`
-	ShowUnreleased          bool                `mapstructure:"show_unreleased"`
-	CheckForUpdates         bool                `mapstructure:"check_for_updates"`
+	FileName                string              `mapstructure:"file_name" yaml:"file_name" json:"fileName"`
+	ExcludedLabels          []string            `mapstructure:"excluded_labels" yaml:"excluded_labels" json:"excludedLabels"`
+	Sections                map[string][]string `mapstructure:"sections" yaml:"sections" json:"sections"`
+	SkipEntriesWithoutLabel bool                `mapstructure:"skip_entries_without_label" yaml:"skip_entries_without_label" json:"skipEntriesWithoutLabel"`
+	ShowUnreleased          bool                `mapstructure:"show_unreleased" yaml:"show_unreleased" json:"showUnreleased"`
+	CheckForUpdates         bool                `mapstructure:"check_for_updates" yaml:"check_for_updates" json:"checkForUpdates"`
+}
+
+func write(data []byte, writer io.Writer) error {
+	_, err := writer.Write(data)
+	return err
+}
+
+func (c *configuration) PrintJSON(writer io.Writer) error {
+	b, err := json.MarshalIndent(c, "", "  ")
+	b = append(b, '\n')
+	if err != nil {
+		return err
+	}
+
+	return write(b, writer)
+}
+
+func (c *configuration) PrintYAML(writer io.Writer) error {
+	b, err := yaml.Marshal(c)
+	if err != nil {
+		return err
+	}
+
+	return write(b, writer)
 }
 
 func InitConfig() error {

--- a/internal/pkg/configuration/configuration_test.go
+++ b/internal/pkg/configuration/configuration_test.go
@@ -1,6 +1,7 @@
 package configuration_test
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/chelnak/gh-changelog/internal/pkg/configuration"
@@ -26,6 +27,73 @@ func TestInitConfigSetsCorrectValues(t *testing.T) {
 	assert.Equal(t, false, config.SkipEntriesWithoutLabel)
 	assert.Equal(t, true, config.ShowUnreleased)
 	assert.Equal(t, true, config.CheckForUpdates)
+}
+
+func TestPrintJSON(t *testing.T) {
+	err := configuration.InitConfig()
+	assert.NoError(t, err)
+
+	config := configuration.Config
+
+	var buf bytes.Buffer
+	err = config.PrintJSON(&buf)
+	assert.NoError(t, err)
+
+	cfg := `{
+  "fileName": "CHANGELOG.md",
+  "excludedLabels": [
+    "maintenance"
+  ],
+  "sections": {
+    "added": [
+      "feature",
+      "enhancement"
+    ],
+    "changed": [
+      "backwards-incompatible"
+    ],
+    "fixed": [
+      "bug",
+      "bugfix",
+      "documentation"
+    ]
+  },
+  "skipEntriesWithoutLabel": false,
+  "showUnreleased": true,
+  "checkForUpdates": true
+}
+`
+	assert.Equal(t, cfg, buf.String())
+}
+
+func TestPrintYAML(t *testing.T) {
+	err := configuration.InitConfig()
+	assert.NoError(t, err)
+
+	config := configuration.Config
+
+	var buf bytes.Buffer
+	err = config.PrintYAML(&buf)
+	assert.NoError(t, err)
+
+	cfg := `file_name: CHANGELOG.md
+excluded_labels:
+- maintenance
+sections:
+  added:
+  - feature
+  - enhancement
+  changed:
+  - backwards-incompatible
+  fixed:
+  - bug
+  - bugfix
+  - documentation
+skip_entries_without_label: false
+show_unreleased: true
+check_for_updates: true
+`
+	assert.Equal(t, cfg, buf.String())
 }
 
 func containsKey(m map[string][]string, key string) bool {


### PR DESCRIPTION
Prior to this PR it was only possible to view config by inspecting the config file created in the users home directory or the current environment variables if any settings had been overridden.

This PR adds the `config` command that allows users to print the current configuration of the application to stdout in either yaml or json format.

Closes #39 