### PR TITLE
Add gitclient tests

### DIFF
--- a/internal/pkg/changelog/builder.go
+++ b/internal/pkg/changelog/builder.go
@@ -4,6 +4,7 @@ package changelog
 
 import (
 	"fmt"
+	"os/exec"
 	"time"
 
 	"github.com/briandowns/spinner"
@@ -83,7 +84,7 @@ func (builder *changelogBuilder) Build() (Changelog, error) {
 	}
 
 	if builder.git == nil {
-		builder.git = gitclient.NewGitClient()
+		builder.git = gitclient.NewGitClient(exec.Command)
 	}
 
 	builder.spinner.Suffix = " Fetching tags..."

--- a/internal/pkg/gitclient/client.go
+++ b/internal/pkg/gitclient/client.go
@@ -15,18 +15,22 @@ type GitClient interface {
 	GetDateOfHash(hash string) (time.Time, error)
 }
 
+type execContext = func(name string, arg ...string) *exec.Cmd
+
 type execOptions struct {
 	args []string
 }
 
 type git struct {
+	execContext execContext
 }
 
 func (g git) exec(opts execOptions) (string, error) {
 	// TODO: Consider not using a private exec function and hardcode
 	// each call to git in the respective command.
 	// For now, the lint check is disabled.
-	output, err := exec.Command("git", opts.args...).Output() // #nosec G204
+	// output, err := exec.Command("git", opts.args...).Output() // #nosec G204
+	output, err := g.execContext("git", opts.args...).Output() // #nosec G204
 	if err != nil {
 		return "", err
 	}
@@ -58,6 +62,8 @@ func (g git) GetDateOfHash(hash string) (time.Time, error) {
 	return time.ParseInLocation(time.RFC3339, date, time.Local)
 }
 
-func NewGitClient() GitClient {
-	return git{}
+func NewGitClient(cmdContext execContext) GitClient {
+	return git{
+		execContext: cmdContext,
+	}
 }

--- a/internal/pkg/gitclient/client_test.go
+++ b/internal/pkg/gitclient/client_test.go
@@ -1,28 +1,95 @@
 package gitclient_test
 
 import (
+	"fmt"
+	"os"
+	"os/exec"
 	"testing"
+	"time"
 
-	"github.com/chelnak/gh-changelog/mocks"
+	"github.com/chelnak/gh-changelog/internal/pkg/gitclient"
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_ItReturnsTheCorrectRepoName(t *testing.T) {
-	mockClient := &mocks.GitHubClient{}
-	mockClient.On("GetRepoName").Return("TestRepo")
+var testStdoutValue = "test"
 
-	repoName := mockClient.GetRepoName()
-	mockClient.AssertExpectations(t)
-
-	assert.Equal(t, "TestRepo", repoName)
+func fakeExecSuccess(command string, args ...string) *exec.Cmd {
+	cs := []string{"-test.run=TestShellProcessSuccess", "--", command}
+	cs = append(cs, args...)
+	expectedOutput := os.Getenv("GO_TEST_PROCESS_EXPECTED_OUTPUT")
+	cmd := exec.Command(os.Args[0], cs...) // #nosec
+	cmd.Env = []string{"GO_TEST_PROCESS=1", fmt.Sprintf("GO_TEST_PROCESS_EXPECTED_OUTPUT=%s", expectedOutput)}
+	return cmd
 }
 
-func TestItReturnsTheCorrectRepoOwner(t *testing.T) {
-	mockClient := &mocks.GitHubClient{}
-	mockClient.On("GetRepoOwner").Return("TestOwner")
+func fakeExecFailure(command string, args ...string) *exec.Cmd {
+	cs := []string{"-test.run=TestShellProcessFailure", "--", command}
+	cs = append(cs, args...)
+	cmd := exec.Command(os.Args[0], cs...) // #nosec
+	cmd.Env = []string{"GO_TEST_PROCESS=1"}
+	return cmd
+}
 
-	repoName := mockClient.GetRepoOwner()
-	mockClient.AssertExpectations(t)
+func TestShellProcessSuccess(t *testing.T) {
+	if os.Getenv("GO_TEST_PROCESS") != "1" {
+		return
+	}
 
-	assert.Equal(t, "TestOwner", repoName)
+	output := testStdoutValue
+	if os.Getenv("GO_TEST_PROCESS_EXPECTED_OUTPUT") != "" {
+		output = os.Getenv("GO_TEST_PROCESS_EXPECTED_OUTPUT")
+	}
+
+	fmt.Fprint(os.Stdout, output)
+	os.Exit(0)
+}
+
+func TestShellProcessFailure(t *testing.T) {
+	if os.Getenv("GO_TEST_PROCESS") != "1" {
+		return
+	}
+	fmt.Fprint(os.Stderr, "error")
+	os.Exit(1)
+}
+
+func TestGetFirstCommitSuccess(t *testing.T) {
+	gitClient := gitclient.NewGitClient(fakeExecSuccess)
+	commit, err := gitClient.GetFirstCommit()
+
+	assert.NoError(t, err)
+	assert.Equal(t, "test", commit)
+}
+
+func TestGetFirstCommitFailure(t *testing.T) {
+	gitClient := gitclient.NewGitClient(fakeExecFailure)
+	_, err := gitClient.GetFirstCommit()
+
+	assert.Error(t, err)
+}
+
+func TestGetLastCommitSuccess(t *testing.T) {
+	gitClient := gitclient.NewGitClient(fakeExecSuccess)
+	commit, err := gitClient.GetLastCommit()
+
+	assert.NoError(t, err)
+	assert.Equal(t, "test", commit)
+}
+
+func TestGetLastCommitFailure(t *testing.T) {
+	gitClient := gitclient.NewGitClient(fakeExecFailure)
+	_, err := gitClient.GetLastCommit()
+
+	assert.Error(t, err)
+}
+
+func TestGetDateOfHashSuccess(t *testing.T) {
+	mockDate := "2022-04-18T19:31:31+00:00"
+	_ = os.Setenv("GO_TEST_PROCESS_EXPECTED_OUTPUT", mockDate)
+
+	gitClient := gitclient.NewGitClient(fakeExecSuccess)
+	date, err := gitClient.GetDateOfHash("test-hash")
+	expectedDate, _ := time.ParseInLocation(time.RFC3339, mockDate, time.Local)
+
+	assert.NoError(t, err)
+	assert.Equal(t, expectedDate, date)
 }


### PR DESCRIPTION
This PR adds tests for the `gitclient`. The test implementation used meant that `gitclient` needed to be slightly refactored so that we can pass in a fake command context when required.