### PR TITLE
Simplify config printing

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -3,7 +3,6 @@
 package cmd
 
 import (
-	"bufio"
 	"errors"
 	"os"
 
@@ -19,27 +18,14 @@ var configCmd = &cobra.Command{
 	Short: "Prints the current configuration to the terminal in either json or yaml format. Defaults to yaml.",
 	Long:  "Prints the current configuration to the terminal in either json or yaml format. Defaults to yaml.",
 	RunE: func(command *cobra.Command, args []string) error {
-
-		writer := bufio.NewWriter(os.Stdout)
-
-		var err error
-		defer func() {
-			err = writer.Flush()
-		}()
-
-		if err != nil {
-			return err
-		}
-
 		switch output {
 		case "json":
-			return configuration.Config.PrintJSON(writer)
+			return configuration.Config.PrintJSON(os.Stdout)
 		case "yaml":
-			return configuration.Config.PrintYAML(writer)
+			return configuration.Config.PrintYAML(os.Stdout)
 		default:
 			return errors.New("invalid output format. Valid values are 'json' and 'yaml'")
 		}
-
 	},
 }
 

--- a/internal/pkg/configuration/configuration.go
+++ b/internal/pkg/configuration/configuration.go
@@ -29,7 +29,7 @@ type configuration struct {
 }
 
 func write(data []byte, writer io.Writer) error {
-	_, err := writer.Write(data)
+	_, err := fmt.Fprint(writer, string(data))
 	return err
 }
 


### PR DESCRIPTION
After reading an article about unit testing stdout, it became clear that using `bufio` for this specific case was overkill. os.Stdout actually implements the writer interface, therefore it's possible to pass it straight in to the methods and switch out `writer.Write` for `fmt.Fprint`.