### PR TITLE
Colorize config output

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -10,7 +10,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var output string
+var (
+	output  string
+	noColor bool
+)
 
 // configCmd is the entry point for printing the applications configuration in the terminal
 var configCmd = &cobra.Command{
@@ -20,9 +23,9 @@ var configCmd = &cobra.Command{
 	RunE: func(command *cobra.Command, args []string) error {
 		switch output {
 		case "json":
-			return configuration.Config.PrintJSON(os.Stdout)
+			return configuration.Config.PrintJSON(noColor, os.Stdout)
 		case "yaml":
-			return configuration.Config.PrintYAML(os.Stdout)
+			return configuration.Config.PrintYAML(noColor, os.Stdout)
 		default:
 			return errors.New("invalid output format. Valid values are 'json' and 'yaml'")
 		}
@@ -31,4 +34,5 @@ var configCmd = &cobra.Command{
 
 func init() {
 	configCmd.Flags().StringVarP(&output, "output", "o", "yaml", "The output format. Valid values are 'json' and 'yaml'. Defaults to 'yaml'.")
+	configCmd.Flags().BoolVarP(&noColor, "no-color", "n", false, "Disable color output")
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/Masterminds/semver/v3 v3.1.1
+	github.com/alecthomas/chroma v0.10.0
 	github.com/briandowns/spinner v1.18.1
 	github.com/charmbracelet/bubbles v0.10.3
 	github.com/charmbracelet/bubbletea v0.20.0
@@ -21,7 +22,6 @@ require (
 )
 
 require (
-	github.com/alecthomas/chroma v0.10.0 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/cli/safeexec v1.0.0 // indirect
 	github.com/cli/shurcooL-graphql v0.0.1 // indirect

--- a/internal/pkg/configuration/configuration_test.go
+++ b/internal/pkg/configuration/configuration_test.go
@@ -36,7 +36,7 @@ func TestPrintJSON(t *testing.T) {
 	config := configuration.Config
 
 	var buf bytes.Buffer
-	err = config.PrintJSON(&buf)
+	err = config.PrintJSON(true, &buf)
 	assert.NoError(t, err)
 
 	cfg := `{
@@ -73,10 +73,11 @@ func TestPrintYAML(t *testing.T) {
 	config := configuration.Config
 
 	var buf bytes.Buffer
-	err = config.PrintYAML(&buf)
+	err = config.PrintYAML(true, &buf)
 	assert.NoError(t, err)
 
-	cfg := `file_name: CHANGELOG.md
+	cfg := `---
+file_name: CHANGELOG.md
 excluded_labels:
 - maintenance
 sections:


### PR DESCRIPTION
This PR adds optional colorization of the config output. In certain situations this can make reading configuration easier and it also looks pretty neat.

There is also an optional --no-color flag that can be passed. This will disable set the chroma formatter to `noop` rather than terminal16m. Currently, the data is still tokenized by chroma but not formatted so it does not print with any ascii codes.

In this implementation it doesn't matter too much because the size of the configuration will always been small so there are no major tradeoffs.. an improved solution could be to skip passing through chroma if the --no-color flag is passed!