### PR TITLE
Fix lexer in PrintYAML method

### DIFF
--- a/internal/pkg/configuration/configuration.go
+++ b/internal/pkg/configuration/configuration.go
@@ -93,7 +93,7 @@ func (c *configuration) PrintYAML(noColor bool, writer io.Writer) error {
 
 	opts := writeOptions{
 		data:      string(y),
-		lexerName: "json",
+		lexerName: "yaml",
 		noColor:   noColor,
 		writer:    writer,
 	}


### PR DESCRIPTION
The lexer was set incorrectly to json in the PrintYaml method. This lead to broken colourisation of the config when printing as yaml.

In this PR we update the lexer to `yaml`.