### PR TITLE
Add a new excluded label default

### DIFF
--- a/internal/pkg/configuration/configuration.go
+++ b/internal/pkg/configuration/configuration.go
@@ -138,7 +138,7 @@ func InitConfig() error {
 
 func setDefaults() {
 	viper.SetDefault("file_name", "CHANGELOG.md")
-	viper.SetDefault("excluded_labels", []string{"maintenance"})
+	viper.SetDefault("excluded_labels", []string{"maintenance", "dependencies"})
 
 	sections := make(map[string][]string)
 	sections["changed"] = []string{"backwards-incompatible"}


### PR DESCRIPTION
This PR adds the `dependencies` label as a default value for the excluded_labels configuration property.

This is so that PRs from dependabot do not show up in changelogs.