### PR TITLE
Properly handle a repo with no tags

### DIFF
--- a/internal/changelog/builder.go
+++ b/internal/changelog/builder.go
@@ -3,6 +3,7 @@
 package changelog
 
 import (
+	"errors"
 	"fmt"
 	"os/exec"
 	"time"
@@ -92,6 +93,11 @@ func (builder *changelogBuilder) Build() (Changelog, error) {
 	if err != nil {
 		builder.spinner.FinalMSG = ""
 		return nil, err
+	}
+
+	if len(tags) == 0 {
+		builder.spinner.FinalMSG = ""
+		return nil, errors.New("there are no tags on this repository to evaluate")
 	}
 
 	err = builder.setNextVersion(tags[0].Name)

--- a/internal/changelog/builder_test.go
+++ b/internal/changelog/builder_test.go
@@ -115,3 +115,19 @@ func TestChangelogBuilderWithAnOlderNextVersion(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, err.Error(), "the next version should be greater than the former: 'v0.0.1' ≤ 'v1.0.0'")
 }
+
+func TestChangelogBuilderWithNoTags(t *testing.T) {
+	_ = configuration.InitConfig()
+
+	mockGitClient := setupMockGitClient()
+	mockGitHubClient := &mocks.GitHubClient{}
+	mockGitHubClient.On("GetTags").Return([]githubclient.Tag{}, nil)
+
+	testBuilder.WithSpinner(true)
+	testBuilder.WithGitClient(mockGitClient)
+	testBuilder.WithGitHubClient(mockGitHubClient)
+
+	_, err := testBuilder.Build()
+	assert.Error(t, err)
+	assert.Equal(t, err.Error(), "there are no tags on this repository to evaluate")
+}


### PR DESCRIPTION
Prior to this commit when `gh changelog new` was executed on a repository with no tags it would cause an `index out of range` error. This error was not handled and would be displayed to the user.

This commit fixes that by checking the length of the tags slice that is returned from `GetTags`. If it is 0 then we return an error so that it properly bubbles up to the user.