### PR TITLE
Disable codeql triggers

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,11 +1,7 @@
 name: "CodeQL"
 
 on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
-  schedule:
+ schedule:
     - cron: '29 22 * * 0'
 
 jobs:


### PR DESCRIPTION
This commit disables codeql triggers for pushes to main and pullrequests.