### PR TITLE
Better logging control

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -15,6 +15,7 @@ import (
 var nextVersion string
 var fromVersion string
 var latestVersion bool
+var logger string
 
 // newCmd is the entry point for creating a new changelog
 var newCmd = &cobra.Command{
@@ -23,7 +24,7 @@ var newCmd = &cobra.Command{
 	Long:  "Creates a new changelog from activity in the current repository.",
 	RunE: func(command *cobra.Command, args []string) error {
 		opts := builder.BuilderOptions{
-			EnableSpinner: true,
+			Logger:        logger,
 			NextVersion:   nextVersion,
 			FromVersion:   fromVersion,
 			LatestVersion: latestVersion,
@@ -68,6 +69,8 @@ func init() {
 		false,
 		"Build the changelog starting from the latest tag. Using this flag will result in a changelog with one entry.\nIt can be useful for generating a changelog to be used in release notes.",
 	)
+
+	newCmd.Flags().StringVar(&logger, "logger", "", "The type of logger to use. Valid values are 'spinner' and 'text'. The default is 'spinner'.")
 
 	newCmd.MarkFlagsMutuallyExclusive("from-version", "latest")
 	newCmd.Flags().SortFlags = false

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/cli/go-gh v0.1.1
 	github.com/fatih/color v1.13.0
 	github.com/jarcoal/httpmock v1.2.0
+	github.com/rs/zerolog v1.28.0
 	github.com/shurcooL/githubv4 v0.0.0-20220922232305-70b4d362a8cb
 	github.com/spf13/cobra v1.5.0
 	github.com/spf13/viper v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -77,6 +77,7 @@ github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnht
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/containerd/console v1.0.3 h1:lIr7SlA5PxZyMV30bDW0MGbiOPXwc63yRuCP0ARubLw=
 github.com/containerd/console v1.0.3/go.mod h1:7LqA/THxQ86k76b8c/EMSiaJ3h1eZkMkXar0TQ1gf3U=
+github.com/coreos/go-systemd/v22 v22.3.3-0.20220203105225-a9a7ef127534/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -98,6 +99,7 @@ github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmV
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
+github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -187,6 +189,7 @@ github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i
 github.com/magiconair/properties v1.8.6 h1:5ibWZ6iY0NctNGWo87LalDlEZ6R41TqbbDamhfG/Qzo=
 github.com/magiconair/properties v1.8.6/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
+github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
@@ -240,6 +243,9 @@ github.com/rivo/uniseg v0.4.2 h1:YwD0ulJSJytLpiaWua0sBDusfsCZohxjxzVTYjwxfV8=
 github.com/rivo/uniseg v0.4.2/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
+github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
+github.com/rs/zerolog v1.28.0 h1:MirSo27VyNi7RJYP3078AA1+Cyzd2GB66qy3aUHvsWY=
+github.com/rs/zerolog v1.28.0/go.mod h1:NILgTygv/Uej1ra5XxGf82ZFSLk58MFGAUS2o6usyD0=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sahilm/fuzzy v0.1.0/go.mod h1:VFvziUEIMCrT6A6tw2RFIXPXXmzXbOsSHF0DOI8ZK9Y=
 github.com/shurcooL/githubv4 v0.0.0-20220922232305-70b4d362a8cb h1:Ptg7eUGaD22iZMracv+h7ghDJkGaeQ1FQ9BnkRB6DOo=
@@ -426,6 +432,7 @@ golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210831042530-f4d43177bf5e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220204135822-1c1b9b1eba6a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220209214540-3681064d5158/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -30,6 +30,7 @@ type configuration struct {
 	SkipEntriesWithoutLabel bool                `mapstructure:"skip_entries_without_label" yaml:"skip_entries_without_label" json:"skipEntriesWithoutLabel"`
 	ShowUnreleased          bool                `mapstructure:"show_unreleased" yaml:"show_unreleased" json:"showUnreleased"`
 	CheckForUpdates         bool                `mapstructure:"check_for_updates" yaml:"check_for_updates" json:"checkForUpdates"`
+	Logger                  string              `mapstructure:"logger" yaml:"logger" json:"logger"`
 }
 
 type writeOptions struct {
@@ -154,4 +155,6 @@ func setDefaults() {
 	viper.SetDefault("check_for_updates", true)
 
 	viper.SetDefault("no_color", false)
+
+	viper.SetDefault("logger", "spinner")
 }

--- a/internal/configuration/configuration_test.go
+++ b/internal/configuration/configuration_test.go
@@ -27,6 +27,7 @@ func TestInitConfigSetsCorrectValues(t *testing.T) {
 	assert.Equal(t, false, config.SkipEntriesWithoutLabel)
 	assert.Equal(t, true, config.ShowUnreleased)
 	assert.Equal(t, true, config.CheckForUpdates)
+	assert.Equal(t, "spinner", config.Logger)
 }
 
 func TestPrintJSON(t *testing.T) {
@@ -61,9 +62,11 @@ func TestPrintJSON(t *testing.T) {
   },
   "skipEntriesWithoutLabel": false,
   "showUnreleased": true,
-  "checkForUpdates": true
+  "checkForUpdates": true,
+  "logger": "spinner"
 }
 `
+
 	assert.Equal(t, cfg, buf.String())
 }
 
@@ -95,6 +98,7 @@ sections:
 skip_entries_without_label: false
 show_unreleased: true
 check_for_updates: true
+logger: spinner
 `
 	assert.Equal(t, cfg, buf.String())
 }

--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -1,0 +1,11 @@
+// Package environment provides helper methods for working with the
+// current environment.
+package environment
+
+import "os"
+
+// IsCI returns true if the CI environment variable is set to true.
+// This is used for most CI systems.
+func IsCI() bool {
+	return os.Getenv("CI") == "true"
+}

--- a/internal/environment/environment_test.go
+++ b/internal/environment/environment_test.go
@@ -1,0 +1,17 @@
+package environment_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/chelnak/gh-changelog/internal/environment"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsCIReturnsTrueWhenRunningInCI(t *testing.T) {
+	_ = os.Setenv("CI", "true")
+	defer func() {
+		_ = os.Unsetenv("CI")
+	}()
+	assert.True(t, environment.IsCI())
+}

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/chelnak/gh-changelog/internal/configuration"
+	"github.com/chelnak/gh-changelog/internal/environment"
 )
 
 // LoggerType is an enum for the different types of logger
@@ -41,6 +42,12 @@ func NewLogger(loggerType LoggerType) Logger {
 func GetLoggerType(name string) (LoggerType, error) {
 	if name == "" {
 		name = configuration.Config.Logger
+
+		// If we're running in a CI environment then we don't want to
+		// use the spinner.
+		if environment.IsCI() {
+			name = "text"
+		}
 	}
 
 	var loggerType LoggerType

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -1,0 +1,57 @@
+// Package logging provides a simple logging interface for the
+// application.
+package logging
+
+import (
+	"fmt"
+
+	"github.com/chelnak/gh-changelog/internal/configuration"
+)
+
+// LoggerType is an enum for the different types of logger
+type LoggerType int64
+
+const (
+	TEXT LoggerType = iota
+	SPINNER
+)
+
+// Logger is the interface for logging in the application.
+type Logger interface {
+	Infof(format string, args ...interface{})
+	Errorf(format string, args ...interface{})
+	Complete()
+	GetType() LoggerType
+}
+
+// NewLogger returns a new logger based on the type passed in.
+func NewLogger(loggerType LoggerType) Logger {
+	switch loggerType {
+	case TEXT:
+		return newTextLogger()
+	case SPINNER:
+		return newSpinnerLogger()
+	default:
+		return newSpinnerLogger()
+	}
+}
+
+// GetLoggerType returns the logger type from the string value
+// passed in. This is a convenience function for the CLI.
+func GetLoggerType(name string) (LoggerType, error) {
+	if name == "" {
+		name = configuration.Config.Logger
+	}
+
+	var loggerType LoggerType
+	switch name {
+	case "text":
+		loggerType = TEXT
+	case "spinner":
+		loggerType = SPINNER
+	default:
+		return loggerType, fmt.Errorf("'%s' is not a valid logger. Valid values are 'spinner' and 'text'", name)
+	}
+
+	return loggerType, nil
+}

--- a/internal/logging/logger_test.go
+++ b/internal/logging/logger_test.go
@@ -1,0 +1,75 @@
+package logging_test
+
+import (
+	"testing"
+
+	"github.com/chelnak/gh-changelog/internal/logging"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewLoggerReturnsTheCorrectType(t *testing.T) {
+	tests := []struct {
+		name     string
+		want     logging.LoggerType
+		hasError bool
+	}{
+		{
+			name:     "returns a text logger",
+			want:     logging.TEXT,
+			hasError: false,
+		},
+		{
+			name:     "returns a spinner logger",
+			want:     logging.SPINNER,
+			hasError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := logging.NewLogger(tt.want)
+			assert.Equal(t, tt.want, got.GetType())
+		})
+	}
+}
+
+func TestGetLoggerTypeReturnsTheCorrectType(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		want     logging.LoggerType
+		hasError bool
+	}{
+		{
+			name:     "returns a text logger",
+			input:    "text",
+			want:     logging.TEXT,
+			hasError: false,
+		},
+		{
+			name:     "returns a spinner logger",
+			input:    "spinner",
+			want:     logging.SPINNER,
+			hasError: false,
+		},
+		{
+			name:     "returns an error for an invalid logger",
+			input:    "invalid",
+			want:     logging.SPINNER,
+			hasError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := logging.GetLoggerType(tt.input)
+			if tt.hasError {
+				assert.Error(t, err)
+				assert.Equal(t, "'invalid' is not a valid logger. Valid values are 'spinner' and 'text'", err.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}

--- a/internal/logging/spinner.go
+++ b/internal/logging/spinner.go
@@ -1,0 +1,44 @@
+package logging
+
+import (
+	"fmt"
+
+	"github.com/chelnak/ysmrr"
+)
+
+type spinnerLogger struct {
+	manager    ysmrr.SpinnerManager
+	spinner    *ysmrr.Spinner
+	loggerType LoggerType
+}
+
+func newSpinnerLogger() Logger {
+	manager := ysmrr.NewSpinnerManager()
+	spinner := manager.AddSpinner("Loading..")
+	manager.Start()
+	return &spinnerLogger{
+		manager:    manager,
+		spinner:    spinner,
+		loggerType: SPINNER,
+	}
+}
+
+func (s *spinnerLogger) Infof(format string, args ...interface{}) {
+	message := fmt.Sprintf(format, args...)
+	s.spinner.UpdateMessage(message)
+}
+
+func (s *spinnerLogger) Errorf(format string, args ...interface{}) {
+	message := fmt.Sprintf(format, args...)
+	s.spinner.UpdateMessage(message)
+	s.spinner.Error()
+}
+
+func (s *spinnerLogger) Complete() {
+	s.spinner.Complete()
+	s.manager.Stop()
+}
+
+func (s *spinnerLogger) GetType() LoggerType {
+	return s.loggerType
+}

--- a/internal/logging/text.go
+++ b/internal/logging/text.go
@@ -1,0 +1,33 @@
+package logging
+
+import (
+	"os"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+)
+
+type textLogger struct {
+	loggerType LoggerType
+}
+
+func newTextLogger() Logger {
+	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
+	return &textLogger{
+		loggerType: TEXT,
+	}
+}
+
+func (t *textLogger) Infof(format string, args ...interface{}) {
+	log.Info().Msgf(format, args...)
+}
+
+func (t *textLogger) Errorf(format string, args ...interface{}) {
+	log.Error().Msgf(format, args...)
+}
+
+func (t *textLogger) Complete() {}
+
+func (t *textLogger) GetType() LoggerType {
+	return t.loggerType
+}

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -196,7 +196,7 @@ func (b *builder) getUnreleasedEntries() error {
 }
 
 func (b *builder) getReleasedEntries(idx int, currentTag githubclient.Tag) error {
-	b.logger.Infof("Processing tags: 🏷️  %s", currentTag.Name)
+	b.logger.Infof("Processing tag: 🏷️  %s", currentTag.Name)
 	previousTag, err := b.getPreviousTag(idx + 1)
 	if err != nil {
 		return err

--- a/pkg/builder/builder_test.go
+++ b/pkg/builder/builder_test.go
@@ -86,8 +86,6 @@ func setupBuilder(opts *builder.BuilderOptions) builder.Builder { // nolint:unpa
 		opts = &builder.BuilderOptions{}
 	}
 
-	opts.EnableSpinner = true
-
 	if opts.GitClient == nil {
 		opts.GitClient = setupMockGitClient()
 	}


### PR DESCRIPTION
This commit adds a new internal package called logging. It exposes the Logger interface. The package also includes two loggers that implement the Logger interface.

TEXT - this logger uses zerolog and will print out a sequential list of events.

SPINNER - even though this is technically not a logger, this option implements a spinner that is used to display events.

The type of logger used is determined by the LoggerType options. The LoggerType is passed to the constructor which will return the correct logging implementation.