### PR TITLE
Fix tags append

### DIFF
--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -171,7 +171,7 @@ func (b *builder) setNextVersion() error {
 		Date: Now(),
 	}
 
-	b.tags = append(b.tags, tag)
+	b.tags = append([]githubclient.Tag{tag}, b.tags...)
 
 	return nil
 }


### PR DESCRIPTION
This commit fixes an issue where nextVersion would get inserted at the end of the array when infact it should have been inserted at the start.