### PR TITLE
Fix markown formatting

### DIFF
--- a/internal/writer/writer.go
+++ b/internal/writer/writer.go
@@ -11,7 +11,8 @@ import (
 	"github.com/chelnak/gh-changelog/pkg/changelog"
 )
 
-var tmplSrc = `# Changelog
+var tmplSrc = `<!-- markdownlint-disable MD024 -->
+# Changelog
 
 All notable changes to this project will be documented in this file.
 
@@ -37,49 +38,45 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 {{range .Added}}
 - {{.}}
 {{- end}}
-{{- end -}}
+{{end}}
 {{- if .Changed }}
 ### Changed
 {{- range .Changed}}
 - {{.}}
 {{- end}}
-{{- end}}
-
+{{end}}
 {{- if .Deprecated }}
 ### Deprecated
 {{range .Deprecated}}
 - {{.}}
 {{- end}}
 {{- end}}
-
 {{- if .Removed }}
 ### Removed
 {{range .Removed}}
 - {{.}}
 {{- end}}
-{{- end}}
-
+{{end}}
 {{- if .Fixed }}
 ### Fixed
 {{range .Fixed}}
 - {{.}}
 {{- end}}
-{{- end}}
-
+{{end}}
 {{- if .Security }}
 ### Security
 {{range .Security}}
 - {{.}}
 {{- end}}
-{{- end}}
-
+{{end}}
 {{- if .Other }}
 ### Other
 {{range .Other}}
 - {{.}}
 {{- end}}
+{{end}}
 {{- end}}
-{{- end}}`
+`
 
 func Write(writer io.Writer, changelog changelog.Changelog) error {
 	tmpl, err := template.New("changelog").Funcs(template.FuncMap{

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -232,7 +232,7 @@ func (b *builder) getReleasedEntries(previousTag, currentTag githubclient.Tag) e
 
 func (b *builder) formatEntryLine(pr githubclient.PullRequest) string {
 	return fmt.Sprintf(
-		"%s [#%d](https://github.com/%s/%s/pull/%d) ([%s](https://github.com/%s))\n",
+		"%s [#%d](https://github.com/%s/%s/pull/%d) ([%s](https://github.com/%s))",
 		pr.Title,
 		pr.Number,
 		b.github.GetRepoOwner(),

--- a/pkg/builder/builder_test.go
+++ b/pkg/builder/builder_test.go
@@ -113,7 +113,7 @@ func TestChangelogBuilder(t *testing.T) {
 
 	assert.Equal(
 		t,
-		"this is a test pr 2 [#2](https://github.com/repo-owner/repo-name/pull/2) ([test-user](https://github.com/test-user))\n",
+		"this is a test pr 2 [#2](https://github.com/repo-owner/repo-name/pull/2) ([test-user](https://github.com/test-user))",
 		changelog.GetEntries()[0].Added[0],
 	)
 }
@@ -158,7 +158,7 @@ func TestWithFromVersion(t *testing.T) {
 	assert.Len(t, changelog.GetEntries(), 1)
 	assert.Equal(
 		t,
-		"this is a test pr 2 [#2](https://github.com/repo-owner/repo-name/pull/2) ([test-user](https://github.com/test-user))\n",
+		"this is a test pr 2 [#2](https://github.com/repo-owner/repo-name/pull/2) ([test-user](https://github.com/test-user))",
 		changelog.GetEntries()[0].Added[0],
 	)
 }
@@ -175,7 +175,7 @@ func TestWithFromLastVersion(t *testing.T) {
 	assert.Len(t, changelog.GetEntries(), 1)
 	assert.Equal(
 		t,
-		"this is a test pr 2 [#2](https://github.com/repo-owner/repo-name/pull/2) ([test-user](https://github.com/test-user))\n",
+		"this is a test pr 2 [#2](https://github.com/repo-owner/repo-name/pull/2) ([test-user](https://github.com/test-user))",
 		changelog.GetEntries()[0].Added[0],
 	)
 }


### PR DESCRIPTION
Prior to this PR the markdown created by this extension would cause markdownlint violations.

This commit ensure that these are fixed.

For MD024 (duplicate headings) a disable comment has now been added to the top of the file.