### PR TITLE
Fix usage on repositories without tags

### DIFF
--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -148,8 +148,8 @@ func (b *builder) updateTags() error {
 		return err
 	}
 
-	if len(tags) == 0 {
-		return errors.New("there are no tags on this repository to evaluate")
+	if len(tags) == 0 && b.nextVersion == "" {
+		return errors.New("there are no tags on this repository to evaluate and the --next-version flag was not provided")
 	}
 
 	b.tags = append(b.tags, tags...)
@@ -158,14 +158,15 @@ func (b *builder) updateTags() error {
 }
 
 func (b *builder) setNextVersion() error {
-	currentVersion := b.tags[0].Name
-
 	if !utils.IsValidSemanticVersion(b.nextVersion) {
 		return fmt.Errorf("'%s' is not a valid semantic version", b.nextVersion)
 	}
+	if len(b.tags) > 0 {
+		currentVersion := b.tags[0].Name
 
-	if !utils.VersionIsGreaterThan(currentVersion, b.nextVersion) {
-		return fmt.Errorf("the next version should be greater than the former: '%s' ≤ '%s'", b.nextVersion, currentVersion)
+		if !utils.VersionIsGreaterThan(currentVersion, b.nextVersion) {
+			return fmt.Errorf("the next version should be greater than the former: '%s' ≤ '%s'", b.nextVersion, currentVersion)
+		}
 	}
 
 	lastCommitSha, err := b.git.GetLastCommit()

--- a/pkg/builder/builder_test.go
+++ b/pkg/builder/builder_test.go
@@ -143,7 +143,7 @@ func TestShouldErrorWithNoTags(t *testing.T) {
 	_, err := builder.BuildChangelog()
 
 	assert.Error(t, err)
-	assert.Equal(t, "there are no tags on this repository to evaluate", err.Error())
+	assert.Equal(t, "there are no tags on this repository to evaluate and the --next-version flag was not provided", err.Error())
 }
 
 func TestWithFromVersion(t *testing.T) {


### PR DESCRIPTION
Prior to this change, if the tool was ran on a repo with no tags (a new project for example) it would fail because there were no tags returned by githubs api.

This change fixes that by updating the builder so that an error is generated only if there are no tags and the --next-version flag has not been provided.