### PR TITLE
Allow local configs

### DIFF
--- a/.changelog.yml
+++ b/.changelog.yml
@@ -1,0 +1,19 @@
+check_for_updates: false
+excluded_labels:
+    - maintenance
+    - dependencies
+file_name: CHANGELOG.md
+logger: spinner
+no_color: false
+sections:
+    added:
+        - feature
+        - enhancement
+    changed:
+        - backwards-incompatible
+    fixed:
+        - bug
+        - bugfix
+        - documentation
+show_unreleased: true
+skip_entries_without_label: false

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -105,17 +105,19 @@ func (c *configuration) PrintYAML(noColor bool, writer io.Writer) error {
 func InitConfig() error {
 	home, _ := os.UserHomeDir()
 
-	viper.SetConfigName("config")
-	viper.SetConfigType("yaml")
+	viper.SetConfigName(".changelog")
+	viper.SetConfigType("yml")
 
 	cfgPath := filepath.Join(home, ".config", "gh-changelog")
-	viper.AddConfigPath(cfgPath)
-
 	if _, err := os.Stat(cfgPath); os.IsNotExist(err) {
 		if err := os.MkdirAll(cfgPath, 0750); err != nil {
 			return fmt.Errorf("failed to create config directory: %s", err)
 		}
 	}
+
+	// Viper search paths in order of precedence
+	viper.AddConfigPath(".")
+	viper.AddConfigPath(cfgPath)
 
 	setDefaults()
 


### PR DESCRIPTION
This commit adds the current working directory as a search path for viper.

It also changes the name of the configuration file to `.changelog.yml`.

If there is a `.changelog.yml` file present in the current directory, gh-changelog will prefer this over the one that is created inside `.config/gh-changelog`.