### PR TITLE
Handle Pre-Releases

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -74,17 +74,16 @@ func requestLatestRelease() (Release, error) {
 }
 
 func VersionIsGreaterThan(currentVersion, nextVersion string) bool {
-	constraint, err := semver.NewConstraint(fmt.Sprintf("> %s", currentVersion))
+	currentSemVer, err := semver.NewVersion(currentVersion)
 	if err != nil {
 		return false
 	}
 
-	version, err := semver.NewVersion(nextVersion)
-	if err != nil {
-		return false
-	}
+	// The nextVersion has already been validated by the builder
+	// so we can safely eat the error.
+	nextSemVer, _ := semver.NewVersion(nextVersion)
 
-	return constraint.Check(version)
+	return nextSemVer.Compare(currentSemVer) == 1
 }
 
 func parseLocalVersion(version string) string {

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -50,6 +50,11 @@ func TestIsValidSemanticVersion(t *testing.T) {
 			want:  true,
 		},
 		{
+			name:  "valid semantic version with pre-release",
+			value: "1.0.0-beta",
+			want:  true,
+		},
+		{
 			name:  "invalid semantic version",
 			value: "asdasdasd1",
 			want:  false,
@@ -84,6 +89,21 @@ func TestVersionIsGreaterThan(t *testing.T) {
 		{
 			name:  "when the version is equal",
 			value: "1.0.0",
+			want:  false,
+		},
+		{
+			name:  "when the version is greater with pre-release",
+			value: "1.0.1-beta",
+			want:  true,
+		},
+		{
+			name:  "version is not greater than with pre-release",
+			value: "0.2.0-beta",
+			want:  false,
+		},
+		{
+			name:  "when the version is equal with pre-release",
+			value: "1.0.0-beta",
 			want:  false,
 		},
 	}


### PR DESCRIPTION
Prior to this change, the generator could not handle pre-releases.

This change updates `utils.VersionIsGreaterThan` so that it uses compare vs the previous constraint.

`Comparse` will take in to consideration pre-releases where as constraints did not.

https://pkg.go.dev/github.com/Masterminds/semver/v3#Version.Compare