### PR TITLE
Fix config initialization

### DIFF
--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -104,9 +104,11 @@ func (c *configuration) PrintYAML(noColor bool, writer io.Writer) error {
 
 func InitConfig() error {
 	home, _ := os.UserHomeDir()
+	file := ".changelog"
+	extension := "yml"
 
-	viper.SetConfigName(".changelog")
-	viper.SetConfigType("yml")
+	viper.SetConfigName(file)
+	viper.SetConfigType(extension)
 
 	cfgPath := filepath.Join(home, ".config", "gh-changelog")
 	if _, err := os.Stat(cfgPath); os.IsNotExist(err) {
@@ -122,7 +124,8 @@ func InitConfig() error {
 	setDefaults()
 
 	if err := viper.ReadInConfig(); err != nil {
-		err := viper.SafeWriteConfig()
+		defaultConfigPath := filepath.Join(cfgPath, fmt.Sprintf("%s.%s", file, extension))
+		err := viper.SafeWriteConfigAs(defaultConfigPath)
 		if err != nil {
 			return fmt.Errorf("failed to write config: %s", err)
 		}


### PR DESCRIPTION
Prior to this change, a .changelog.yml would always be created in the current working directory.

The local config file should be optional and only used when users need to override certain values.

To restore the original functionality we now use SafeWriteConfigAs to ensure the config is placed in the expected directory on first run.

The ability to initialize local config should be fixed in #120.