### PR TITLE
Improve sections ordering

### DIFF
--- a/internal/writer/writer.go
+++ b/internal/writer/writer.go
@@ -56,8 +56,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 {{range .Deprecated}}
 - {{.}}
 {{- end}}
-{{- end}}
-{{if .Added }}
+{{end}}
+{{- if .Added }}
 ### Added
 {{range .Added}}
 - {{.}}

--- a/internal/writer/writer.go
+++ b/internal/writer/writer.go
@@ -33,9 +33,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 [Full Changelog](https://github.com/{{$.GetRepoOwner}}/{{$.GetRepoName}}/compare/{{getFirstCommit}}...{{.Tag}})
 {{- end -}}
 
-{{if .Added }}
-### Added
-{{range .Added}}
+{{- if .Security }}
+### Security
+{{range .Security}}
 - {{.}}
 {{- end}}
 {{end}}
@@ -45,27 +45,27 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 - {{.}}
 {{- end}}
 {{end}}
-{{- if .Deprecated }}
-### Deprecated
-{{range .Deprecated}}
-- {{.}}
-{{- end}}
-{{- end}}
 {{- if .Removed }}
 ### Removed
 {{range .Removed}}
 - {{.}}
 {{- end}}
 {{end}}
-{{- if .Fixed }}
-### Fixed
-{{range .Fixed}}
+{{- if .Deprecated }}
+### Deprecated
+{{range .Deprecated}}
+- {{.}}
+{{- end}}
+{{- end}}
+{{if .Added }}
+### Added
+{{range .Added}}
 - {{.}}
 {{- end}}
 {{end}}
-{{- if .Security }}
-### Security
-{{range .Security}}
+{{- if .Fixed }}
+### Fixed
+{{range .Fixed}}
 - {{.}}
 {{- end}}
 {{end}}


### PR DESCRIPTION
In order to better match changes that follow semver, group changes that
trigger a MAJOR bump ("Changed", "Removed") _before_ those that trigger
a MINOR bump ("Added"), _before_ those that trigger a PATCH bump
("Fixed").

"Security", "Deprecated" and "Other" changes do not have a corresponding
part as far as semver is concerned, so put them where it makes more
sense: "Security" at the top, "Deprecated" just after "Removed" and
"Other" at the end.

The ordering is now:
  - Security
  - Changed
  - Removed
  - Deprecated
  - Added
  - Fixed
  - Other
