### PR TITLE
bugfix: Release creation toggling RepoName & RepoOwner

### DIFF
--- a/pkg/changelog/changelog.go
+++ b/pkg/changelog/changelog.go
@@ -89,7 +89,7 @@ func (c *changelog) Tail() *entry.Entry {
 }
 
 // NewChangelog creates a new changelog datastructure.
-func NewChangelog(repoName string, repoOwner string) Changelog {
+func NewChangelog(repoOwner string, repoName string) Changelog {
 	return &changelog{
 		repoName:   repoName,
 		repoOwner:  repoOwner,


### PR DESCRIPTION
The release creation toggling the repoName with repoOwner and vice versa which causing link to be incorrect.