### PR TITLE
Add missing line between "Changed" title and list

### DIFF
--- a/internal/writer/writer.go
+++ b/internal/writer/writer.go
@@ -41,7 +41,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 {{end}}
 {{- if .Changed }}
 ### Changed
-{{- range .Changed}}
+{{range .Changed}}
 - {{.}}
 {{- end}}
 {{end}}


### PR DESCRIPTION
When a release has breaking changes, they are listed in a "Changed"
section.  Unlike other sections, this section title is directly followed
by the change list, while other sections have a blank line to separate
the title and the change list.

For consistency make sure we have that blank line after all titles.
