### PR TITLE
Fix get latest panic on single entry changelog

### DIFF
--- a/internal/get/get.go
+++ b/internal/get/get.go
@@ -28,8 +28,10 @@ func parseChangelog(fileName string) (changelog.Changelog, error) {
 func changelogWithSingleEntry(entry entry.Entry, repoName, repoOwner string) changelog.Changelog {
 	// Isolate the entry
 	entry.Next = nil
-	entry.PrevTag = entry.Previous.Tag
-	entry.Previous = nil
+	if entry.Previous != nil {
+		entry.PrevTag = entry.Previous.Tag
+		entry.Previous = nil
+	}
 
 	cl := changelog.NewChangelog(repoOwner, repoName)
 	cl.Insert(entry)

--- a/internal/get/get_test.go
+++ b/internal/get/get_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 var fileName string = "CHANGELOG.md"
+var singleEntryFileName string = "single_CHANGELOG.md"
 
 func TestGetAll(t *testing.T) {
 	cl, err := get.GetAll(fileName)
@@ -30,6 +31,18 @@ func TestGetLatest(t *testing.T) {
 	count := len(cl.GetEntries())
 	assert.Equal(t, 1, count)
 	assert.Equal(t, "v0.13.0", cl.GetEntries()[0].PrevTag)
+}
+
+func TestGetLatestWithNoPrevious(t *testing.T) {
+	cl, err := get.GetLatest(singleEntryFileName)
+
+	// Should not error
+	assert.Nil(t, err)
+
+	// Should have 1 entry
+	count := len(cl.GetEntries())
+	assert.Equal(t, 1, count)
+	assert.Equal(t, "", cl.GetEntries()[0].PrevTag)
 }
 
 func TestGetVersionWithAValidVersion(t *testing.T) {

--- a/internal/get/single_CHANGELOG.md
+++ b/internal/get/single_CHANGELOG.md
@@ -1,0 +1,10 @@
+<!-- markdownlint-disable MD024 -->
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
+
+## [v0.1.0](https://github.com/chelnak/gh-changelog/tree/v0.1.0) - 2022-04-15
+
+[Full Changelog](https://github.com/chelnak/gh-changelog/compare/42d4c93b23eaf307c5f9712f4c62014fe38332bd...v0.1.0)


### PR DESCRIPTION
* Caused by #148
* Reproduce with a single entry CHANGELOG.md (added test)

```
$ gh-changelog get --latest
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0xafc65d]

goroutine 1 [running]:
github.com/chelnak/gh-changelog/internal/get.changelogWithSingleEntry({0x0, 0x0, {0xc000512428, 0x6}, {0x0, 0x0}, {0x0, 0xeddc4ce80, 0x0}, {0x0, ...}, ...}, ...)
        /home/h0tw1r3/dev/gh-changelog/internal/get/get.go:31 +0x5d
github.com/chelnak/gh-changelog/internal/get.GetLatest({0xc000473340?, 0x0?})
        /home/h0tw1r3/dev/gh-changelog/internal/get/get.go:70 +0x10e
github.com/chelnak/gh-changelog/cmd.glob..func2(0x2354fc0?, {0xe2e32c?, 0x1?, 0x1?})
        /home/h0tw1r3/dev/gh-changelog/cmd/get.go:43 +0x67
github.com/spf13/cobra.(*Command).execute(0x2354fc0, {0xc000519d20, 0x1, 0x1})
        /home/h0tw1r3/dev/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:916 +0x862
github.com/spf13/cobra.(*Command).ExecuteC(0x2355860)
        /home/h0tw1r3/dev/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:1044 +0x3bd
github.com/spf13/cobra.(*Command).Execute(...)
        /home/h0tw1r3/dev/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:968
github.com/chelnak/gh-changelog/cmd.Execute()
        /home/h0tw1r3/dev/gh-changelog/cmd/root.go:93 +0x25
main.main()
        /home/h0tw1r3/dev/gh-changelog/main.go:10 +0x19
```