### PR TITLE
add new notes output to get command

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -45,7 +45,7 @@ var newCmd = &cobra.Command{
 			return err
 		}
 
-		if err := writer.Write(f, changelog); err != nil {
+		if err := writer.Write(f, writer.TmplSrcStandard, changelog); err != nil {
 			return err
 		}
 

--- a/internal/writer/writer.go
+++ b/internal/writer/writer.go
@@ -11,7 +11,7 @@ import (
 	"github.com/chelnak/gh-changelog/pkg/changelog"
 )
 
-var tmplSrc = `<!-- markdownlint-disable MD024 -->
+const tmplStandard = `<!-- markdownlint-disable MD024 -->
 # Changelog
 
 All notable changes to this project will be documented in this file.
@@ -79,7 +79,57 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 {{- end}}
 `
 
-func Write(writer io.Writer, changelog changelog.Changelog) error {
+const tmplNotes = `{{range .GetEntries }}
+{{- if .Security }}
+### Security
+{{range .Security}}
+- {{.}}
+{{- end}}
+{{end}}
+{{- if .Changed }}
+### Changed
+{{range .Changed}}
+- {{.}}
+{{- end}}
+{{end}}
+{{- if .Removed }}
+### Removed
+{{range .Removed}}
+- {{.}}
+{{- end}}
+{{end}}
+{{- if .Deprecated }}
+### Deprecated
+{{range .Deprecated}}
+- {{.}}
+{{- end}}
+{{end}}
+{{- if .Added }}
+### Added
+{{range .Added}}
+- {{.}}
+{{- end}}
+{{end}}
+{{- if .Fixed }}
+### Fixed
+{{range .Fixed}}
+- {{.}}
+{{- end}}
+{{end}}
+{{- if .Other }}
+### Other
+{{range .Other}}
+- {{.}}
+{{- end}}
+{{end}}
+{{- end}}`
+
+const (
+	TmplSrcStandard = tmplStandard
+	TmplSrcNotes    = tmplNotes
+)
+
+func Write(writer io.Writer, tmplSrc string, changelog changelog.Changelog) error {
 	tmpl, err := template.New("changelog").Funcs(template.FuncMap{
 		"getFirstCommit": func() string {
 			git := gitclient.NewGitClient(exec.Command)

--- a/internal/writer/writer_test.go
+++ b/internal/writer/writer_test.go
@@ -40,7 +40,7 @@ func Test_ItWritesOutAChangelogInTheCorrectFormat(t *testing.T) {
 	mockChangelog.AddUnreleased([]string{"Unreleased 1", "Unreleased 2"})
 
 	var buf bytes.Buffer
-	err := writer.Write(&buf, mockChangelog)
+	err := writer.Write(&buf, writer.TmplSrcStandard, mockChangelog)
 
 	assert.NoError(t, err)
 
@@ -58,4 +58,12 @@ func Test_ItWritesOutAChangelogInTheCorrectFormat(t *testing.T) {
 	assert.Regexp(t, "### Other", buf.String())
 	assert.Regexp(t, "- Other 1", buf.String())
 	assert.Regexp(t, "- Other 2", buf.String())
+
+	buf.Reset()
+	err = writer.Write(&buf, writer.TmplSrcNotes, mockChangelog)
+
+	assert.NoError(t, err)
+
+	assert.NotRegexp(t, regexp.MustCompile(`## \[v1.0.0\]\(https:\/\/github.com\/repo-owner\/repo-name\/tree\/v1.0.0\)`), buf.String())
+	assert.NotRegexp(t, regexp.MustCompile(`\[Full Changelog\]\(https:\/\/github.com\/repo-owner\/repo-name\/compare\/v0.9.0\.\.\.v1.0.0\)`), buf.String())
 }


### PR DESCRIPTION
Basically an alternate template to the changelog format that only works with a single "Entry" and doesn't output the changelog header or footer.
A "full" changelog style entry is usually not desired when adding to annotated tags or a Github release message.

Ideally, as this extension is GH specific, I would like to see the release notes more release friendly (automatic contributors section).

Instead of this:
```markdown
### Added
- Improve sections ordering https://github.com/chelnak/gh-changelog/pull/139 ([smortex](https://github.com/smortex))
```

Output this for release notes:
```markdown
### Added
- #139: Improve sections ordering (@smortex)
```

Which ends up looking like:

<img width="864" alt="image" src="https://github.com/chelnak/gh-changelog/assets/809115/c01e632c-b665-481d-a3cc-8363735a0413">
